### PR TITLE
don't use /var/task/headless-chromium when running locally

### DIFF
--- a/packages/serverless-plugin/src/index.js
+++ b/packages/serverless-plugin/src/index.js
@@ -135,7 +135,7 @@ export default class ServerlessChrome {
       const launcherOptions = {
         ...customPluginOptions,
         flags: customPluginOptions.flags || [],
-        chromePath: this.webpack ? '/var/task/headless-chromium' : undefined,
+        chromePath: (this.webpack && !process.env.IS_LOCAL) ? '/var/task/headless-chromium' : undefined,
       }
 
       // Read in the wrapper handler code template


### PR DESCRIPTION
If you are using webpack, this plugin assumes headless-chromium is present at /var/task/headless-chromium
But this isn't true when running locally with `invoke local`